### PR TITLE
Combined bug fixing commit

### DIFF
--- a/benchmarks/bms/tomcat/tomcat.patch
+++ b/benchmarks/bms/tomcat/tomcat.patch
@@ -10,3 +10,24 @@ diff -N -u -r tomcat.orig/apache-tomcat-6.0.20-src/build.properties.default apac
  
  # ----- Commons Logging, version 1.1 or later -----
  commons-logging-version=1.1.1
+
+--- build/apache-tomcat-6.0.20-src/build.properties.default	2017-11-24 16:45:54.563087654 +1100
++++ build.properties-new.default	2017-11-24 16:46:55.752018154 +1100
+@@ -45,7 +45,7 @@
+
+ base-commons.loc=http://archive.apache.org/dist/commons
+ base-tomcat.loc=http://archive.apache.org/dist/tomcat
+-base-sf.loc=http://softlayer.dl.sourceforge.net
++base-sf.loc=https://ncu.dl.sourceforge.net
+
+ # ----- Commons Logging, version 1.1 or later -----
+ commons-logging-version=1.1.1
+@@ -90,7 +90,7 @@
+ nsis.installoptions.dll=${nsis.home}/Plugins/InstallOptions.dll
+ nsis.nsexec.dll=${nsis.home}/Plugins/nsExec.dll
+ nsis.nsisdl.dll=${nsis.home}/Plugins/NSISdl.dll
+-nsis.loc=${base-sf.loc}/nsis/nsis-2.37.zip
++nsis.loc=${base-sf.loc}/project/nsis/NSIS%202/2.37/nsis-2.37.zip
+
+
+# ----- Commons Daemon, version 1.0-Alpha or later -----

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -76,35 +76,35 @@ BUILDING:
 	<property name="dacapo.doc.dir" value="${basedir}/doc"/>
 	<property name="dacapo.src.dir" value="${basedir}/src"/>
 
-    <target name="check-svn-present">
-        <available property="svn.present" file=".svn" type="dir"/>
-        <property name="svn.exe" value="svn"/>
+    <target name="check-git-present">
+        <available property="git.present" file="../.git" type="dir"/>
+        <property name="git.exe" value="git"/>
     </target>
 
-    <target name="extract-svn-revision" depends="check-svn-present" if="svn.present">
-        <exec executable="${svn.exe}" failonerror="no" failifexecutionfails="no">
-            <arg value="info"/>
-            <redirector outputproperty="svn.revision">
+    <target name="extract-git-revision" depends="check-git-present" if="git.present">
+        <exec executable="${git.exe}" failonerror="no" failifexecutionfails="no">
+            <arg line="show --abbrev-commit HEAD"/>
+            <redirector outputproperty="git.revision">
                 <outputfilterchain>
-                    <linecontains>
-                        <contains value="Revision: "/>
-                    </linecontains>
+                    <linecontainsregexp>
+                        <regexp pattern="^commit [a-z0-9]+$"/>
+                    </linecontainsregexp>
                     <tokenfilter>
-                        <replacestring from="Revision: " to=""/>
+                        <replacestring from="commit " to=""/>
                     </tokenfilter>
                 </outputfilterchain>
             </redirector>
         </exec>
     </target>
 
-    <target name="get-svn-revision" depends="extract-svn-revision">
+    <target name="get-git-revision" depends="extract-git-revision" unless="git.revision">
         <!-- set property if not already set -->
-        <property name="svn.revision" value="unknown"/>
+        <property name="git.revision" value="unknown"/>
     </target>
 
-    <target name="set-build-version-info" depends="get-svn-revision">
+    <target name="set-build-version-info" depends="get-git-revision">
         <property name="build.nickname" value="development"/>
-        <property name="build.version"  value="head-r${svn.revision}"/>
+        <property name="build.version"  value="head-r${git.revision}"/>
     </target>
 
     <target name="init" depends="set-build-version-info">
@@ -226,13 +226,13 @@ BUILDING:
         <echo file="${dacapo.build.dir}/MANIFEST.MF" append="yes">Implementation-Version: ${build.version}${line.separator}</echo>
 
     	<!-- form the top level info -->
-        <copy file="${basedir}/LICENSE-2.0.txt" todir="${dacapo.build.dir}"/>
-        <copy file="${basedir}/README.txt" todir="${dacapo.build.dir}"/>
+        <copy file="${basedir}/../LICENSE" todir="${dacapo.build.dir}"/>
+        <copy file="${basedir}/../README.md" todir="${dacapo.build.dir}"/>
         <copy file="${basedir}/RELEASE_NOTES.txt" todir="${dacapo.build.dir}"/>
 
     	<!-- this forms the base document section -->
-		<copy file="${basedir}/LICENSE-2.0.txt" tofile="${dacapo.build.doc.dir}/LICENSE.txt" />
-		<copy file="${basedir}/README.txt" todir="${dacapo.build.doc.dir}" />
+        <copy file="${basedir}/../LICENSE" todir="${dacapo.build.dir}"/>
+        <copy file="${basedir}/../README.md" todir="${dacapo.build.dir}"/>
 		<copy file="${basedir}/RELEASE_NOTES.txt" todir="${dacapo.build.doc.dir}" />
 
 		<copy todir="${dacapo.build.doc.dir}">

--- a/benchmarks/harness/src/org/dacapo/harness/TestHarness.java
+++ b/benchmarks/harness/src/org/dacapo/harness/TestHarness.java
@@ -256,7 +256,8 @@ public class TestHarness {
 
   {
     try {
-      JarFile jarFile = new JarFile(new File(TestHarness.class.getProtectionDomain().getCodeSource().getLocation().getFile()));
+      String url = TestHarness.class.getProtectionDomain().getCodeSource().getLocation().getFile();
+      JarFile jarFile = new JarFile(url.replace("!/harness", "").replace("file:", ""));
 
       Manifest manifest = jarFile.getManifest();
       Attributes attributes = manifest.getMainAttributes();

--- a/benchmarks/libs/commons-logging/build.xml
+++ b/benchmarks/libs/commons-logging/build.xml
@@ -19,7 +19,7 @@
 
     <property name="lib-build-top" value="${lib-build-dir}/${lib-name}-${lib-version}-src"/>
 
-    <target name="unpack" depends="untar"/>
+    <target name="unpack" depends="untar, patch"/>
 
     <target name="build">
         <ant antfile="build.xml" dir="${lib-build-top}" inheritAll="false">

--- a/benchmarks/libs/commons-logging/commons-logging.patch
+++ b/benchmarks/libs/commons-logging/commons-logging.patch
@@ -1,0 +1,19 @@
+--- commons-logging-1.1.1-src/build.xml	2007-11-22 10:27:52.000000000 +1100
++++ ../build-new.xml	2017-11-27 11:37:15.057501309 +1100
+@@ -221,13 +221,14 @@
+     - Running this target will download all the necessary dependencies into the "lib" subdirectory.
+     -->
+   <property name="getlibs.base" value="http://repo1.maven.org/maven"/>
++  <property name="maven.central" value="http://central.maven.org/maven2"/>
+   <target name="getlibs">
+     <mkdir dir="lib"/>
+-    <get dest="lib/junit-3.8.1.jar" src="${getlibs.base}/junit/jars/junit-3.8.1.jar"/>
++    <get dest="lib/junit-3.8.1.jar" src="${maven.central}/junit/junit/3.8.1/junit-3.8.1.jar"/>
+     <get dest="lib/logkit-1.0.1.jar" src="${getlibs.base}/logkit/jars/logkit-1.0.1.jar"/>
+     <get dest="lib/avalon-framework-4.1.3.jar" src="${getlibs.base}/avalon-framework/jars/avalon-framework-4.1.3.jar"/>
+     <get dest="lib/log4j-1.2.12.jar" src="${getlibs.base}/log4j/jars/log4j-1.2.12.jar"/>
+-    <get dest="lib/servletapi-2.3.jar" src="${getlibs.base}/servletapi/jars/servletapi-2.3.jar"/>
++    <get dest="lib/servletapi-2.3.jar" src="${maven.central}/servletapi/servletapi/2.3/servletapi-2.3.jar"/>
+   </target>
+
+   <target name="init"

--- a/benchmarks/libs/daytrader/build.xml
+++ b/benchmarks/libs/daytrader/build.xml
@@ -58,7 +58,7 @@
 
     <property name="jstl-version" value="1.2"/>
     <property name="jstl-name" value="jstl"/>
-    <property name="jstl-url" value="${java-dev-url}/glassfish/org/glassfish/web/${jstl-name}-impl/${jstl-version}"/>
+    <property name="jstl-url" value="${maven-repo-url}/org/glassfish/web/${jstl-name}-impl/${jstl-version}"/>
     <property name="jstl-jar" value="${jstl-name}-impl-${jstl-version}.jar"/>
 
     <property name="oro-version" value="2.0.8"/>

--- a/benchmarks/libs/daytrader/downloads/jstl-impl-1.2.jar.MD5
+++ b/benchmarks/libs/daytrader/downloads/jstl-impl-1.2.jar.MD5
@@ -1,1 +1,1 @@
-f67ef6ab1f83a302c333cbd0fecccc0e
+7eb0e63ce8cc6d4e5791ce08d80d8de0

--- a/benchmarks/libs/h2/build.xml
+++ b/benchmarks/libs/h2/build.xml
@@ -12,7 +12,7 @@
 
     <property name="lib-name" value="h2"/>
     <property name="lib-version" value="1.2.123"/>
-    <property name="lib-url" value="http://repo2.maven.org/maven2/com/h2database/${lib-name}/${lib-version}/"/>
+    <property name="lib-url" value="http://repo2.maven.org/maven2/com/h2database/${lib-name}/${lib-version}"/>
     <property name="lib-src" value="h2-${lib-version}.jar"/>
 
     <import file="../common.xml"/>

--- a/benchmarks/libs/janino/build.xml
+++ b/benchmarks/libs/janino/build.xml
@@ -12,7 +12,7 @@
 
     <property name="lib-name" value="janino"/>
     <property name="lib-version" value="2.5.15"/>
-        <property name="lib-url" value="http://dist.codehaus.org/janino"/>
+    <property name="lib-url" value="http://pkgs.fedoraproject.org/repo/pkgs/janino/janino-2.5.15.zip/087b6db3eabb6175f228a58958f816aa"/>
     <property name="lib-src" value="janino-${lib-version}.zip"/>
 
     <import file="../common.xml"/>

--- a/benchmarks/libs/junit/build.xml
+++ b/benchmarks/libs/junit/build.xml
@@ -8,11 +8,12 @@
  -->
 <project name="junit" default="all" basedir="../..">
     <description>junit library, required by pmd, hsqldb and derby</description>
+    <property name="sourceforge.dl.j.url" value="http://jaist.dl.sourceforge.net"/>
     <property file="ant/dacapo.properties"/>
 
     <property name="lib-name" value="junit"/>
     <property name="lib-version" value="4.7"/>
-    <property name="lib-url" value="${sourceforge.dl.url}/junit"/>
+    <property name="lib-url" value="${sourceforge.dl.j.url}}/project/junit/junit/${lib-version}"/>
     <property name="lib-src" value="junit${lib-version}.zip"/>
 
     <import file="../common.xml"/>


### PR DESCRIPTION
Fix the broken link problem for h2 and junit

Fix the broken link for janino package

Update the patch file for tomcat for fixing one broken link

Add the patch file for libs/commons-logging to fix the broken link for downloaded package

Fix the broken link of jstl and update the checksum for jstl

Delete the extra space in md5 checksum file for jstl

Deleting the echo in libs/common.xml

fix: assuming DaCapo is managed by git, properly extract commit hash from git

remove extra space

no fail on error

fix: correctly point to jar file so to extract version info