### PR TITLE
Edit download dependencies for cassandra and h20 due to download URLs…

### DIFF
--- a/benchmarks/bms/cassandra/build.xml
+++ b/benchmarks/bms/cassandra/build.xml
@@ -85,18 +85,17 @@
     </target>
 
     <property name="slf4j-version" value="1.7.25"/>
-    <property name="slf4j-url" value="https://www.slf4j.org/dist"/>
-    <property name="slf4j-tgz" value="slf4j-${slf4j-version}.tar.gz"/>
+    <property name="slf4j-url" value="https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/${slf4j-version}"/>
+    <property name="slf4j-jar" value="slf4j-simple-${slf4j-version}.jar"/>
 
     <target name="get-slf4j-simple-jar">
         <antcall target="check-source">
             <param name="target-dir" value="${bm-downloads}"/>
             <param name="target-url" value="${slf4j-url}"/>
-            <param name="target-file" value="${slf4j-tgz}"/>
+            <param name="target-file" value="${slf4j-jar}"/>
         </antcall>
-        <untar src="${bm-downloads}/${slf4j-tgz}" dest="${bm-build-dir}" compression="gzip"/>
         <property name="slf4j-dir" value="${bm-build-dir}/slf4j-${slf4j-version}"/>
-        <property name="slf4j-simple-jar" value="${slf4j-dir}/slf4j-simple-${slf4j-version}.jar"/>
+        <property name="slf4j-simple-jar" value="${bm-downloads}/slf4j-simple-${slf4j-version}.jar"/>
     </target>
 
     <target name="libs">

--- a/benchmarks/libs/commons-beanutils/build.xml
+++ b/benchmarks/libs/commons-beanutils/build.xml
@@ -18,7 +18,7 @@
     <!-- Downloading from sourceforge -->
     <property name="lib-version" value="1.9.3"/>
     <property name="lib-src" value="${lib-name}-${lib-version}-bin.tar.gz"/>
-    <property name="lib-url" value="https://mirrors.tuna.tsinghua.edu.cn/apache//commons/beanutils/binaries"/>
+    <property name="lib-url" value="https://archive.apache.org/dist/commons/beanutils/binaries"/>
     <property name="lib-jar" value="${lib-name}-${lib-version}.jar"/>
 
     <import file="../common.xml"/>


### PR DESCRIPTION
… going stale.

Hi - As I was trying to learn the new DaCapo I noticed some of the dependency download URLs were stale. I changed them to what seemed like might be more long lived locations and now everything builds.
I think this applies only to the Cassandra and h2o benchmarks dependencies.
Thanks,
Eric
