### PR TITLE
Fixed download path to old Apache Commons Collections jar

### DIFF
--- a/benchmarks/libs/commons-collections/build.xml
+++ b/benchmarks/libs/commons-collections/build.xml
@@ -18,7 +18,7 @@
     <!-- Downloading from sourceforge -->
     <property name="lib-version" value="3.2.2"/>
     <property name="lib-src" value="${lib-name}-${lib-version}-bin.tar.gz"/>
-    <property name="lib-url" value="${apache.mirror}/commons/collections/binaries"/>
+    <property name="lib-url" value="${apache.dl.url}/commons/collections/binaries"/>
     <property name="lib-jar" value="${lib-name}-${lib-version}.jar"/>
 
     <import file="../common.xml"/>


### PR DESCRIPTION
This fixes a broken download link for `commons-collections-3.2.2.jar`.  (Since that file is cached, the broken link did not older cloned repositories but did break attempts to build after a fresh checkout.)
