### PR TITLE
Get Xalan 2.7.2 from archive.apache.org

### DIFF
--- a/benchmarks/bms/fop/build.xml
+++ b/benchmarks/bms/fop/build.xml
@@ -26,7 +26,7 @@
             <antcall target="check-source">
             <!-- explicitly include xalan jar to ensure a suitable TransformerFactory is present, even in old JVMs -->
             <param name="target-dir" value="${bm-downloads}"/>
-            <param name="target-url" value="https://dlcdn.apache.org/xalan/xalan-j/binaries"/>
+            <param name="target-url" value="https://archive.apache.org/dist/xalan/xalan-j/binaries/"/>
             <param name="target-file" value="xalan-j_2_7_2-bin.zip"/>
         </antcall>
     </target>


### PR DESCRIPTION
Xalan 2.7.2 is no longer the latest release, so we need to get it from `archive.apache.org` instead of `dlcdn.apache.org`