### PR TITLE
Kafka client deletes existing topics and recreates the topics before benchmarking

### DIFF
--- a/benchmarks/bms/kafka/kafka.cnf
+++ b/benchmarks/bms/kafka/kafka.cnf
@@ -4,15 +4,15 @@ benchmark kafka
 
 size small args "simple_produce_bench-small.json", "10000"
   output stdout digest 0xd054f76402d83d91bc9824746d89c489c458a103,
-         stderr digest 0xd28f6cbef9f8331245d79c1e0632efd73b069b99;
+         stderr digest 0x49eb5f30bb81b66c3e38a78f9122256c85254479;
          
 size default args "simple_produce_bench.json", "1000000"
   output stdout digest 0xd054f76402d83d91bc9824746d89c489c458a103,
-         stderr digest 0x4edb3257a0c7c91fd7fc9ac16b0d010739ab3f91;
+         stderr digest 0x36fed859a569f5840cd873e556ce3028dcac3371;
          
 size large args "simple_produce_bench-large.json", "10000000"
   output stdout digest 0xd054f76402d83d91bc9824746d89c489c458a103,
-         stderr digest 0x0437129e2ee7fcf2733f26ee8b0edeb9d6688cf8;
+         stderr digest 0x452a8ac06032778f38bc1853b00dbdfb170bea3b;
 
 description
   short	     "Apache Kafka® is a distributed streaming platform.",

--- a/benchmarks/bms/kafka/kafka.patch
+++ b/benchmarks/bms/kafka/kafka.patch
@@ -1,6 +1,6 @@
 diff -ur ./kafka-3.3.1-src/config/log4j.properties ../build/kafka-3.3.1-src/config/log4j.properties
 --- ./kafka-3.3.1-src/config/log4j.properties	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/config/log4j.properties	2023-08-04 05:44:07.094029751 +0000
++++ ../build/kafka-3.3.1-src/config/log4j.properties	2023-09-28 07:45:35.897670292 +0000
 @@ -14,8 +14,8 @@
  # limitations under the License.
  
@@ -63,7 +63,7 @@ diff -ur ./kafka-3.3.1-src/config/log4j.properties ../build/kafka-3.3.1-src/conf
  
 diff -ur ./kafka-3.3.1-src/config/server.properties ../build/kafka-3.3.1-src/config/server.properties
 --- ./kafka-3.3.1-src/config/server.properties	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/config/server.properties	2023-08-04 05:44:07.094029751 +0000
++++ ../build/kafka-3.3.1-src/config/server.properties	2023-09-28 07:45:35.897670292 +0000
 @@ -59,7 +59,7 @@
  ############################# Log Basics #############################
  
@@ -87,7 +87,7 @@ diff -ur ./kafka-3.3.1-src/config/server.properties ../build/kafka-3.3.1-src/con
  
 diff -ur ./kafka-3.3.1-src/config/tools-log4j.properties ../build/kafka-3.3.1-src/config/tools-log4j.properties
 --- ./kafka-3.3.1-src/config/tools-log4j.properties	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/config/tools-log4j.properties	2023-08-04 05:44:07.094029751 +0000
++++ ../build/kafka-3.3.1-src/config/tools-log4j.properties	2023-09-28 07:45:35.897670292 +0000
 @@ -13,7 +13,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
@@ -99,7 +99,7 @@ diff -ur ./kafka-3.3.1-src/config/tools-log4j.properties ../build/kafka-3.3.1-sr
  log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
 diff -ur ./kafka-3.3.1-src/config/zookeeper.properties ../build/kafka-3.3.1-src/config/zookeeper.properties
 --- ./kafka-3.3.1-src/config/zookeeper.properties	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/config/zookeeper.properties	2023-08-04 05:44:07.094029751 +0000
++++ ../build/kafka-3.3.1-src/config/zookeeper.properties	2023-09-28 07:45:35.897670292 +0000
 @@ -13,7 +13,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
@@ -111,7 +111,7 @@ diff -ur ./kafka-3.3.1-src/config/zookeeper.properties ../build/kafka-3.3.1-src/
  # disable the per-ip limit on the number of connections since this is a non-production config
 diff -ur ./kafka-3.3.1-src/core/src/main/scala/kafka/admin/TopicCommand.scala ../build/kafka-3.3.1-src/core/src/main/scala/kafka/admin/TopicCommand.scala
 --- ./kafka-3.3.1-src/core/src/main/scala/kafka/admin/TopicCommand.scala	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/core/src/main/scala/kafka/admin/TopicCommand.scala	2023-08-04 05:44:07.094029751 +0000
++++ ../build/kafka-3.3.1-src/core/src/main/scala/kafka/admin/TopicCommand.scala	2023-09-28 07:45:35.897670292 +0000
 @@ -73,7 +73,8 @@
          exitCode = 1
      } finally {
@@ -124,7 +124,7 @@ diff -ur ./kafka-3.3.1-src/core/src/main/scala/kafka/admin/TopicCommand.scala ..
  
 diff -ur ./kafka-3.3.1-src/core/src/main/scala/kafka/log/LogManager.scala ../build/kafka-3.3.1-src/core/src/main/scala/kafka/log/LogManager.scala
 --- ./kafka-3.3.1-src/core/src/main/scala/kafka/log/LogManager.scala	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/core/src/main/scala/kafka/log/LogManager.scala	2023-08-04 05:44:07.094029751 +0000
++++ ../build/kafka-3.3.1-src/core/src/main/scala/kafka/log/LogManager.scala	2023-09-28 07:45:35.897670292 +0000
 @@ -76,7 +76,7 @@
    import LogManager._
  
@@ -136,7 +136,7 @@ diff -ur ./kafka-3.3.1-src/core/src/main/scala/kafka/log/LogManager.scala ../bui
    private val currentLogs = new Pool[TopicPartition, UnifiedLog]()
 diff -ur ./kafka-3.3.1-src/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala ../build/kafka-3.3.1-src/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
 --- ./kafka-3.3.1-src/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala	2023-08-04 05:44:07.094029751 +0000
++++ ../build/kafka-3.3.1-src/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala	2023-09-28 07:45:35.897670292 +0000
 @@ -237,7 +237,7 @@
          Some(Utils.loadProps(absolutePath))
        } catch {
@@ -148,7 +148,7 @@ diff -ur ./kafka-3.3.1-src/core/src/main/scala/kafka/server/BrokerMetadataCheckp
            error(s"Failed to read meta.properties file under dir $absolutePath", e)
 diff -ur ./kafka-3.3.1-src/tests/spec/simple_produce_bench.json ../build/kafka-3.3.1-src/tests/spec/simple_produce_bench.json
 --- ./kafka-3.3.1-src/tests/spec/simple_produce_bench.json	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/tests/spec/simple_produce_bench.json	2023-08-04 05:44:07.094029751 +0000
++++ ../build/kafka-3.3.1-src/tests/spec/simple_produce_bench.json	2023-09-28 07:45:35.897670292 +0000
 @@ -23,16 +23,16 @@
    "durationMs": 10000000,
    "producerNode": "node0",
@@ -172,8 +172,24 @@ diff -ur ./kafka-3.3.1-src/tests/spec/simple_produce_bench.json ../build/kafka-3
      }
 diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java ../build/kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
 --- ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java	2023-08-04 05:44:07.094029751 +0000
-@@ -187,16 +187,16 @@
++++ ../build/kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java	2023-09-28 07:45:35.897670292 +0000
+@@ -20,6 +20,7 @@
+ import com.fasterxml.jackson.databind.node.LongNode;
+ import com.fasterxml.jackson.databind.node.ObjectNode;
+ import net.sourceforge.argparse4j.ArgumentParsers;
++
+ import net.sourceforge.argparse4j.inf.ArgumentParser;
+ import net.sourceforge.argparse4j.inf.ArgumentParserException;
+ import net.sourceforge.argparse4j.inf.Namespace;
+@@ -31,6 +32,7 @@
+ import org.apache.kafka.trogdor.common.JsonUtil;
+ import org.apache.kafka.trogdor.common.Node;
+ import org.apache.kafka.trogdor.common.Platform;
++
+ import org.apache.kafka.trogdor.rest.AgentStatusResponse;
+ import org.apache.kafka.trogdor.rest.CreateWorkerRequest;
+ import org.apache.kafka.trogdor.rest.DestroyWorkerRequest;
+@@ -187,16 +189,16 @@
              e.printStackTrace(out);
              return false;
          }
@@ -183,20 +199,20 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/agent/
          if (error == null || error.isEmpty()) {
 -            out.println("Task succeeded with status " +
 -                JsonUtil.toPrettyJsonString(workerManager.workerStates().get(EXEC_WORKER_ID).status()));
-+            //out.println("Task succeeded with status " +
++            // out.println("Task succeeded with status " +
 +            //    JsonUtil.toPrettyJsonString(workerManager.workerStates().get(EXEC_WORKER_ID).status()));
              return true;
          } else {
 -            out.println("Task failed with status " +
 -                JsonUtil.toPrettyJsonString(workerManager.workerStates().get(EXEC_WORKER_ID).status()) +
 -                " and error " + error);
-+            //out.println("Task failed with status " +
-+            //    JsonUtil.toPrettyJsonString(workerManager.workerStates().get(EXEC_WORKER_ID).status()) +
++            // out.println("Task failed with status " +
++            //   JsonUtil.toPrettyJsonString(workerManager.workerStates().get(EXEC_WORKER_ID).status()) +
 +            //    " and error " + error);
              return false;
          }
      }
-@@ -250,7 +250,7 @@
+@@ -250,7 +252,7 @@
          final Agent agent = new Agent(platform, Scheduler.SYSTEM, restServer, resource);
          restServer.start(resource);
          Exit.addShutdownHook("agent-shutdown-hook", () -> {
@@ -205,18 +221,20 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/agent/
              try {
                  agent.beginShutdown();
                  agent.waitForShutdown();
-@@ -265,11 +265,15 @@
+@@ -265,11 +267,15 @@
              } catch (Exception e) {
                  System.out.println("Unable to parse the supplied task spec.");
                  e.printStackTrace();
 -                Exit.exit(1);
-+                agent.beginShutdown();                 
-+                //Exit.exit(1);
-             }
-             TaskSpec effectiveSpec = agent.rebaseTaskSpecTime(spec);
+-            }
+-            TaskSpec effectiveSpec = agent.rebaseTaskSpecTime(spec);
 -            Exit.exit(agent.exec(effectiveSpec, System.out) ? 0 : 1);
 -        }
-+            agent.exec(effectiveSpec, System.out);
++                agent.beginShutdown();                 
++                //Exit.exit(1);
++            }            
++            TaskSpec effectiveSpec = agent.rebaseTaskSpecTime(spec);            
++            agent.exec(effectiveSpec, System.out);            
 +            agent.beginShutdown();
 +            //Remove Exit.exit because the agent is executed in the Dacapo thread
 +            //Exit.exit(agent.exec(effectiveSpec, System.out) ? 0 : 1);
@@ -224,10 +242,83 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/agent/
          agent.waitForShutdown();
      }
  }
+diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java ../build/kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+--- ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java	2022-09-29 19:03:49.000000000 +0000
++++ ../build/kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java	2023-09-28 07:54:20.458881135 +0000
+@@ -106,6 +106,7 @@
+ 
+     private static final int ADMIN_REQUEST_TIMEOUT = 25000;
+     private static final int CREATE_TOPICS_CALL_TIMEOUT = 180000;
++    private static final int CREATE_TOPICS_CALL_WAITTIME = 1000;
+     private static final int MAX_CREATE_TOPICS_BATCH_SIZE = 10;
+ 
+             //Map<String, Map<Integer, List<Integer>>> topics) throws Throwable {
+@@ -135,7 +136,7 @@
+         try (Admin adminClient
+                  = createAdminClient(bootstrapServers, commonClientConf, adminClientConf)) {
+             createTopics(log, adminClient, topics, failOnExisting);
+-        } catch (Exception e) {
++        } catch (Exception e) { 
+             log.warn("Failed to create or verify topics {}", topics, e);
+             throw e;
+         }
+@@ -180,6 +181,7 @@
+         long startMs = Time.SYSTEM.milliseconds();
+         int tries = 0;
+         List<String> existingTopics = new ArrayList<>();
++        boolean existingDeleted = false;
+ 
+         Map<String, NewTopic> newTopics = new HashMap<>();
+         for (NewTopic newTopic : topics) {
+@@ -205,7 +207,7 @@
+                 Future<Void> future = entry.getValue();
+                 try {
+                     future.get();
+-                    log.debug("Successfully created {}.", topicName);
++                    log.debug("Successfully created {}.", topicName);                    
+                 } catch (Exception e) {
+                     if ((e.getCause() instanceof TimeoutException)
+                         || (e.getCause() instanceof NotEnoughReplicasException)) {
+@@ -213,7 +215,8 @@
+                                  e.getCause().getMessage());
+                         topicsToCreate.add(topicName);
+                     } else if (e.getCause() instanceof TopicExistsException) {
+-                        log.info("Topic {} already exists.", topicName);
++                        log.info("Topic {} already exists.", topicName);                        
++                        topicsToCreate.add(topicName);
+                         existingTopics.add(topicName);
+                     } else {
+                         log.warn("Failed to create {}", topicName, e.getCause());
+@@ -224,12 +227,17 @@
+             if (topicsToCreate.isEmpty()) {
+                 break;
+             }
++            if (!existingTopics.isEmpty() && !existingDeleted) {
++                adminClient.deleteTopics(existingTopics);
++                existingDeleted = true;
++            }
+             if (Time.SYSTEM.milliseconds() > startMs + CREATE_TOPICS_CALL_TIMEOUT) {
+                 String str = "Unable to create topic(s): " +
+                              Utils.join(topicsToCreate, ", ") + "after " + tries + " attempt(s)";
+                 log.warn(str);
+                 throw new TimeoutException(str);
+             }
++            Thread.sleep(CREATE_TOPICS_CALL_WAITTIME);
+         }
+         return existingTopics;
+     }
 diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java ../build/kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
 --- ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java	2022-09-29 19:03:49.000000000 +0000
-+++ ../build/kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java	2023-08-04 05:44:07.094029751 +0000
-@@ -55,6 +55,9 @@
++++ ../build/kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java	2023-09-28 07:45:35.897670292 +0000
+@@ -27,6 +27,7 @@
+ import org.apache.kafka.clients.producer.ProducerRecord;
+ import org.apache.kafka.clients.producer.RecordMetadata;
+ import org.apache.kafka.common.TopicPartition;
++import org.apache.kafka.common.errors.TopicExistsException;
+ import org.apache.kafka.common.internals.KafkaFutureImpl;
+ import org.apache.kafka.common.serialization.ByteArraySerializer;
+ import org.apache.kafka.common.utils.ThreadUtils;
+@@ -55,6 +56,9 @@
  import java.util.concurrent.atomic.AtomicBoolean;
  import java.util.concurrent.atomic.AtomicLong;
  
@@ -237,7 +328,7 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/worklo
  public class ProduceBenchWorker implements TaskWorker {
      private static final Logger log = LoggerFactory.getLogger(ProduceBenchWorker.class);
      
-@@ -72,6 +75,14 @@
+@@ -72,6 +76,14 @@
  
      private KafkaFutureImpl<String> doneFuture;
  
@@ -252,33 +343,21 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/worklo
      public ProduceBenchWorker(String id, ProduceBenchSpec spec) {
          this.id = id;
          this.spec = spec;
-@@ -79,7 +90,19 @@
+@@ -79,7 +91,7 @@
  
      @Override
      public void start(Platform platform, WorkerStatusTracker status,
 -                      KafkaFutureImpl<String> doneFuture) {
-+        KafkaFutureImpl<String> doneFuture) {
-+        try {
-+            Class<?> clazz = Class.forName("org.dacapo.harness.LatencyReporter", true, ProduceBenchWorker.class.getClassLoader());
-+            dacapoStart = clazz.getMethod("start", int.class);
-+            dacapoEnd = clazz.getMethod("endIdx", int.class);
-+            dacapoStarting = clazz.getMethod("requestsStarting");
-+            dacapoFinished = clazz.getMethod("requestsFinished");
-+        } catch (ClassNotFoundException e) {
-+            System.err.println("Failed to access DaCapo latency reporter: "+e);
-+        } catch (NoSuchMethodException e) {
-+            System.err.println("Failed trying to create latency stats: "+e);
-+        }
-+        dacapoStarting();
++                      KafkaFutureImpl<String> doneFuture) {       
          if (!running.compareAndSet(false, true)) {
              throw new IllegalStateException("ProducerBenchWorker is already running.");
          }
-@@ -91,6 +114,28 @@
+@@ -90,12 +102,32 @@
+             ThreadUtils.createThreadFactory("ProduceBenchWorkerThread%d", false));
          this.status = status;
          this.doneFuture = doneFuture;
-         executor.submit(new Prepare());
-+
-+        
+-        executor.submit(new Prepare());
++        executor.submit(new Prepare());        
 +    }
 +
 +    public void dacapoStarting() {
@@ -302,7 +381,35 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/worklo
      }
  
      public class Prepare implements Runnable {
-@@ -131,23 +176,61 @@
+         @Override
+-        public void run() {
++        public void run() {            
+             try {
+                 Map<String, NewTopic> newTopics = new HashMap<>();
+                 HashSet<TopicPartition> active = new HashSet<>();
+@@ -119,8 +151,20 @@
+                 }
+                 status.update(new TextNode("Creating " + newTopics.keySet().size() + " topic(s)"));
+                 WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.commonClientConf(),
+-                                         spec.adminClientConf(), newTopics, false);
++                    spec.adminClientConf(), newTopics, false);               
+                 status.update(new TextNode("Created " + newTopics.keySet().size() + " topic(s)"));
++                try {
++                    Class<?> clazz = Class.forName("org.dacapo.harness.LatencyReporter", true, ProduceBenchWorker.class.getClassLoader());
++                    dacapoStart = clazz.getMethod("start", int.class);
++                    dacapoEnd = clazz.getMethod("endIdx", int.class);
++                    dacapoStarting = clazz.getMethod("requestsStarting");
++                    dacapoFinished = clazz.getMethod("requestsFinished");
++                } catch (ClassNotFoundException e) {
++                    System.err.println("Failed to access DaCapo latency reporter: "+e);
++                } catch (NoSuchMethodException e) {
++                    System.err.println("Failed trying to create latency stats: "+e);
++                }
++                dacapoStarting(); 
+                 executor.submit(new SendRecords(active));
+             } catch (Throwable e) {
+                 WorkerUtils.abort(log, "Prepare", e, doneFuture);
+@@ -131,23 +175,61 @@
      private static class SendRecordsCallback implements Callback {
          private final SendRecords sendRecords;
          private final long startMs;
@@ -365,7 +472,7 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/worklo
      /**
       * A subclass of Throttle which flushes the Producer right before the throttle injects a delay.
       * This avoids including throttling latency in latency measurements.
-@@ -293,6 +376,7 @@
+@@ -293,6 +375,7 @@
          }
  
          private void sendMessage() throws InterruptedException {
@@ -373,7 +480,7 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/worklo
              if (!partitionsIterator.hasNext())
                  partitionsIterator = activePartitions.iterator();
  
-@@ -306,11 +390,18 @@
+@@ -306,11 +389,18 @@
                      partition.topic(), partition.partition(), keys.next(), values.next());
              }
              sendFuture = producer.send(record,
@@ -393,7 +500,7 @@ diff -ur ./kafka-3.3.1-src/trogdor/src/main/java/org/apache/kafka/trogdor/worklo
              histogram.add(durationMs);
          }
      }
-@@ -407,6 +498,8 @@
+@@ -407,6 +497,8 @@
  
      @Override
      public void stop(Platform platform) throws Exception {

--- a/benchmarks/bms/kafka/src/org/dacapo/kafka/ClientRunner.java
+++ b/benchmarks/bms/kafka/src/org/dacapo/kafka/ClientRunner.java
@@ -12,7 +12,6 @@ public class ClientRunner{
     private Method topicCommand;
     long timerBase = 0;
     private int txCount;
-    private final static long timeout = (long) (1000L * Float.parseFloat(System.getProperty("dacapo.timeout.dialation")));
 
     ClientRunner(int txCount) throws Exception{
         this.txCount = txCount;
@@ -43,14 +42,9 @@ public class ClientRunner{
         setTxCount.invoke(null, txCount);
         // Using the Trogodr exec mode to send requests
         agentStarter.invoke(null, (Object) new String[]{"-c", agentConfig, "-n", "node0", "--exec", produceBench});
-        topicCommand.invoke(null, (Object) new String[]{"--bootstrap-server", "localhost:9092", "--delete", "--topic", "dacapo-1,dacapo-2,dacapo-3,dacapo-4"});
-
+        System.err.println("Finished");
     }
 
     void finishUp() throws Exception{
-        // Sleep one second waiting for the Kafka broker to delete the topics
-        System.err.println("Waiting " + timeout + "ms for cleanup...");
-        Thread.sleep(timeout);
-        System.err.println("Finished");
     }
 }


### PR DESCRIPTION
[issue-226](https://github.com/dacapobench/dacapobench/issues/226) is caused by the topics are deleted in the middle of an iteration. This patch addresses issue with:

* If topics exist when creating topics,  the Kafka client deletes the existing topics, then in a loop to recreate the topics until the server doesn't return error.
* Move the dacapoStarting() after creating the topics.