### PR TITLE
Fix #279: Conditionally call startIdx

### DIFF
--- a/benchmarks/harness/src/org/dacapo/harness/LatencyReporter.java
+++ b/benchmarks/harness/src/org/dacapo/harness/LatencyReporter.java
@@ -102,7 +102,9 @@ public class LatencyReporter {
       next_idx = inc();
     }
     idx = next_idx++;
-    startIdx(idx, id);
+    if (idx < txbegin.length) {
+      startIdx(idx, id);
+    }
     return idx;
   }
   private static void startIdx(int index, int threadID) {


### PR DESCRIPTION
This PR restores the bounds check to ensure we don't call `startIdx`with a larger index than the size of the array. Resolves #279.