### PR TITLE
Upgrade beanutils version to 1.10.0

### DIFF
--- a/benchmarks/libs/commons-beanutils/build.xml
+++ b/benchmarks/libs/commons-beanutils/build.xml
@@ -16,7 +16,7 @@
     <property name="lib-name" value="commons-beanutils"/>
 
     <!-- Downloading from sourceforge -->
-    <property name="lib-version" value="1.9.4"/>
+    <property name="lib-version" value="1.10.0"/>
     <property name="lib-src" value="${lib-name}-${lib-version}-bin.tar.gz"/>
     <property name="lib-url" value="${apache.mirror}/commons/beanutils/binaries"/>
     <property name="lib-jar" value="${lib-name}-${lib-version}.jar"/>


### PR DESCRIPTION
This was causing build issues for me:
```
     [exec] get-source:
     [exec]       [get] Getting: https://downloads.apache.org/commons/beanutils/binaries/commons-beanutils-1.9.4-bin.tar.gz
     [exec]       [get] To: /root/dacapobench/benchmarks/libs/commons-beanutils/downloads/commons-beanutils-1.9.4-bin.tar.gz
     [exec]       [get] Error opening connection java.io.FileNotFoundException: https://downloads.apache.org/commons/beanutils/binaries/commons-beanutils-1.9.4-bin.tar.gz
     [exec]       [get] Error opening connection java.io.FileNotFoundException: https://downloads.apache.org/commons/beanutils/binaries/commons-beanutils-1.9.4-bin.tar.gz
     [exec]       [get] Error opening connection java.io.FileNotFoundException: https://downloads.apache.org/commons/beanutils/binaries/commons-beanutils-1.9.4-bin.tar.gz
     [exec]       [get] Can't get https://downloads.apache.org/commons/beanutils/binaries/commons-beanutils-1.9.4-bin.tar.gz to /root/dacapobench/benchmarks/libs/commons-beanutils/downloads/commons-beanutils-1.9.4-bin.tar.gz
     [exec] 
     [exec] BUILD FAILED
     [exec] /root/dacapobench/benchmarks/bms/common.xml:49: The following error occurred while executing this line:
     [exec] /root/dacapobench/benchmarks/libs/libs.xml:146: The following error occurred while executing this line:
     [exec] /root/dacapobench/benchmarks/libs/common.xml:32: The following error occurred while executing this line:
     [exec] /root/dacapobench/benchmarks/libs/common.xml:38: The following error occurred while executing this line:
     [exec] /root/dacapobench/benchmarks/util.xml:31: The following error occurred while executing this line:
     [exec] /root/dacapobench/benchmarks/util.xml:50: Can't get https://downloads.apache.org/commons/beanutils/binaries/commons-beanutils-1.9.4-bin.tar.gz to /root/dacapobench/benchmarks/libs/commons-beanutils/downloads/commons-beanutils-1.9.4-bin.tar.gz
     [exec] 
     [exec] Total time: 44 seconds
     [exec] Result: 1
     [echo] h2o: FAIL

BUILD FAILED
/root/dacapobench/benchmarks/build.xml:576: The following error occurred while executing this line:
/root/dacapobench/benchmarks/build.xml:530: h2o: FAIL
```

Based on https://dlcdn.apache.org//commons/beanutils/binaries/, this seems to be the latest version.

I then ran into another issue equivalent to https://github.com/dacapobench/dacapobench/issues/313, so this fix is not sufficient to fix the h2o build (I'm not sure if beanutils is used anywhere else).

EDIT: This seems like it was because I was working on the main branch, while the fix for that issue is in `chopin-mr1`. I'm not sure where this PR should be merge into then.