### PR TITLE
Update commons-beanutils version to 1.11.0

### DIFF
--- a/benchmarks/libs/commons-beanutils/build.xml
+++ b/benchmarks/libs/commons-beanutils/build.xml
@@ -16,7 +16,7 @@
     <property name="lib-name" value="commons-beanutils"/>
 
     <!-- Downloading from sourceforge -->
-    <property name="lib-version" value="1.9.4"/>
+    <property name="lib-version" value="1.11.0"/>
     <property name="lib-src" value="${lib-name}-${lib-version}-bin.tar.gz"/>
     <property name="lib-url" value="${apache.mirror}/commons/beanutils/binaries"/>
     <property name="lib-jar" value="${lib-name}-${lib-version}.jar"/>
@@ -30,4 +30,3 @@
     </target>
 
 </project>
-


### PR DESCRIPTION
Hi all,

As descripte in https://github.com/dacapobench/dacapobench/issues/364, dacapo build fails since commons-beanutils-1.9.4 not available anymore. This PR update version to 1.11.0.