### PR TITLE
Add GitHub Actions CI workflow for building benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,142 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, 'chopin*', 'dev-chopin*' ]
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        benchmark: [avrora, batik, biojava, cassandra, eclipse, fop, graphchi, h2, h2o, jme, jython, kafka, luindex, lusearch, pmd, spring, sunflow, tomcat, tradebeans, tradesoap, xalan, zxing]
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.x'
+
+    - name: Install Python dependencies
+      run: |
+        pip install requests future tabulate wheel
+
+    - name: Install Temurin and Ant
+      run: |
+        sudo mkdir -p /etc/apt/keyrings
+        wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee /etc/apt/keyrings/adoptium.asc
+        echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+        sudo apt-get update
+        sudo apt-get install -y temurin-8-jdk temurin-11-jdk ant cvs subversion mercurial nodejs npm zstd
+
+    - name: Configure local.properties
+      run: |
+        cd benchmarks
+        touch local.properties
+        echo "make=/usr/bin/make" > local.properties
+        echo "build.failonerror=true" >> local.properties
+        
+        # Find Java 11 path
+        JAVA11_HOME=$(find /usr/lib/jvm -name "temurin-11*" -type d | head -n 1)
+        echo "jdk.11.home=$JAVA11_HOME" >> local.properties
+        
+        echo "Configured local.properties:"
+        cat local.properties
+
+    - name: Build benchmark
+      run: |
+        cd benchmarks
+        
+        # Find Java 8 path and set as default for this step
+        JAVA8_HOME=$(find /usr/lib/jvm -name "temurin-8*" -type d | head -n 1)
+        export JAVA_HOME=$JAVA8_HOME
+        export PATH=$JAVA_HOME/bin:$PATH
+        
+        echo "Using Java version:"
+        java -version
+        
+        ant ${{ matrix.benchmark }}
+
+    - name: Compress Artifacts
+      run: |
+        cd benchmarks
+        DIR_NAME=$(find . -maxdepth 1 -name "dacapo-evaluation-git-*" -type d | head -n 1)
+        JAR_NAME=$(find . -maxdepth 1 -name "dacapo-evaluation-git-*.jar" -type f | head -n 1)
+        tar --zstd -cf "dacapo-${{ matrix.benchmark }}.tar.zst" "$DIR_NAME" "$JAR_NAME"
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: dacapo-${{ matrix.benchmark }}.tar.zst
+        path: benchmarks/dacapo-${{ matrix.benchmark }}.tar.zst
+
+  full-build:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.x'
+
+    - name: Install Python dependencies
+      run: |
+        pip install requests future tabulate wheel
+
+    - name: Install Temurin and Ant
+      run: |
+        sudo mkdir -p /etc/apt/keyrings
+        wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee /etc/apt/keyrings/adoptium.asc
+        echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+        sudo apt-get update
+        sudo apt-get install -y temurin-8-jdk temurin-11-jdk ant cvs subversion mercurial nodejs npm zstd
+
+    - name: Configure local.properties
+      run: |
+        cd benchmarks
+        touch local.properties
+        echo "make=/usr/bin/make" > local.properties
+        echo "build.failonerror=true" >> local.properties
+        
+        # Find Java 11 path
+        JAVA11_HOME=$(find /usr/lib/jvm -name "temurin-11*" -type d | head -n 1)
+        echo "jdk.11.home=$JAVA11_HOME" >> local.properties
+        
+        echo "Configured local.properties:"
+        cat local.properties
+
+    - name: Build all benchmarks
+      run: |
+        cd benchmarks
+        
+        # Find Java 8 path and set as default for this step
+        JAVA8_HOME=$(find /usr/lib/jvm -name "temurin-8*" -type d | head -n 1)
+        export JAVA_HOME=$JAVA8_HOME
+        export PATH=$JAVA_HOME/bin:$PATH
+        
+        echo "Using Java version:"
+        java -version
+        
+        ant
+
+    - name: Compress Artifacts
+      run: |
+        cd benchmarks
+        DIR_NAME=$(find . -maxdepth 1 -name "dacapo-evaluation-git-*" -type d | head -n 1)
+        JAR_NAME=$(find . -maxdepth 1 -name "dacapo-evaluation-git-*.jar" -type f | head -n 1)
+        tar --zstd -cf "dacapo-full.tar.zst" "$DIR_NAME" "$JAR_NAME"
+
+    - name: Upload Full Artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: dacapo-full.tar.zst
+        path: benchmarks/dacapo-full.tar.zst

--- a/benchmarks/libs/commons-beanutils/build.xml
+++ b/benchmarks/libs/commons-beanutils/build.xml
@@ -18,7 +18,7 @@
     <!-- Downloading from sourceforge -->
     <property name="lib-version" value="1.9.4"/>
     <property name="lib-src" value="${lib-name}-${lib-version}-bin.tar.gz"/>
-    <property name="lib-url" value="${apache.mirror}/commons/beanutils/binaries"/>
+    <property name="lib-url" value="${apache.dl.url}/commons/beanutils/binaries"/>
     <property name="lib-jar" value="${lib-name}-${lib-version}.jar"/>
 
     <import file="../common.xml"/>


### PR DESCRIPTION
Add a GitHub Actions CI workflow that builds each DaCapo benchmark.

## Changes

### CI Workflow (`.github/workflows/ci.yml`)
- **Matrix build**: Builds all 22 benchmarks in parallel, each as a separate job
- **Full build**: Runs a combined build after all individual benchmarks succeed
- **Triggers**: Push on `main`/`chopin*`/`dev-chopin*`, all PRs, weekly schedule, and manual dispatch
- **JDK setup**: Installs Temurin JDK 8 and 11 via apt (required by the build)
- **Artifacts**: Compresses build outputs (data folder + jar) with zstd and uploads per-benchmark

### Bug Fix (`benchmarks/libs/commons-beanutils/build.xml`)
- Fix broken download URL for commons-beanutils to use the Apache archive URL

### Action Versions
- `actions/checkout@v5`
- `actions/setup-python@v6`
- `actions/upload-artifact@v7`